### PR TITLE
Expose suite-specific KDF and AEAD interface.

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,6 @@
+export type { AeadKey } from "./src/interfaces/aeadKey.ts";
 export type { CipherSuiteParams } from "./src/interfaces/cipherSuiteParams.ts";
+export type { KdfInterface } from "./src/interfaces/kdfInterface.ts";
 export type {
   EncryptionContextInterface,
   RecipientContextInterface,

--- a/src/bundles/hmac/LICENSE
+++ b/src/bundles/hmac/LICENSE
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Original work (c) Marco Paland (marco@paland.com) 2015-2018, PALANDesign Hannover, Germany
+
+Deno port Copyright (c) 2019 Noah Anabiik Schwarz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/bundles/hmac/mod.ts
+++ b/src/bundles/hmac/mod.ts
@@ -1,0 +1,123 @@
+import { SHA256 } from "../sha256/mod.ts";
+import { SHA512 } from "../sha512/mod.ts";
+
+const SHA256_REGEX: RegExp = /^\s*sha-?256\s*$/i;
+const SHA512_REGEX: RegExp = /^\s*sha-?512\s*$/i;
+
+/** An interface representation of a hash algorithm implementation. */
+export interface Hash {
+  hashSize: number;
+  init(): Hash;
+  update(msg: Uint8Array): Hash;
+  digest(): Uint8Array;
+}
+
+/** A class representation of the HMAC algorithm. */
+export class HMAC {
+  readonly hashSize: number;
+  readonly B: number;
+  readonly iPad: number;
+  readonly oPad: number;
+
+  private iKeyPad!: Uint8Array;
+  private oKeyPad!: Uint8Array;
+  private hasher: Hash;
+
+  /** Creates a new HMAC instance. */
+  constructor(hasher: Hash, key?: Uint8Array) {
+    this.hashSize = hasher.hashSize;
+    this.hasher = hasher;
+    this.B = this.hashSize <= 32 ? 64 : 128; // according to RFC4868
+    this.iPad = 0x36;
+    this.oPad = 0x5c;
+
+    if (key) {
+      this.init(key);
+    }
+  }
+
+  /** Initializes an HMAC instance. */
+  init(key: Uint8Array): HMAC {
+    if (!key) {
+      key = new Uint8Array(0);
+    }
+
+    // process the key
+    let _key: Uint8Array = new Uint8Array(key);
+
+    if (_key.length > this.B) {
+      // keys longer than blocksize are shortened
+      this.hasher.init();
+      _key = this.hasher.update(key).digest() as Uint8Array;
+    }
+
+    // zeropadr
+    if (_key.byteLength < this.B) {
+      const tmp: Uint8Array = new Uint8Array(this.B);
+      tmp.set(_key, 0);
+      _key = tmp;
+    }
+
+    // setup the key pads
+    this.iKeyPad = new Uint8Array(this.B);
+    this.oKeyPad = new Uint8Array(this.B);
+
+    for (let i: number = 0; i < this.B; ++i) {
+      this.iKeyPad[i] = this.iPad ^ _key[i];
+      this.oKeyPad[i] = this.oPad ^ _key[i];
+    }
+
+    // blackout key
+    _key.fill(0);
+
+    // initial hash
+    this.hasher.init();
+    this.hasher.update(this.iKeyPad);
+
+    return this;
+  }
+
+  /** Update the HMAC with additional message data. */
+  update(
+    msg: Uint8Array = new Uint8Array(0)
+  ): HMAC {
+    this.hasher.update(msg);
+
+    return this;
+  }
+
+  /** Finalize the HMAC with additional message data. */
+  digest(): Uint8Array {
+    const sum1: Uint8Array = this.hasher.digest() as Uint8Array; // get sum 1
+
+    this.hasher.init();
+
+    return this.hasher
+      .update(this.oKeyPad)
+      .update(sum1)
+      .digest();
+  }
+}
+
+/** Returns a HMAC of the given msg and key using the indicated hash. */
+export function hmac(
+  hash: string,
+  key: Uint8Array,
+  msg?: Uint8Array,
+): string | Uint8Array {
+  if (SHA256_REGEX.test(hash)) {
+    return new HMAC(new SHA256())
+      .init(key)
+      .update(msg)
+      .digest();
+  }
+  if (SHA512_REGEX.test(hash)) {
+    return new HMAC(new SHA512())
+      .init(key)
+      .update(msg)
+      .digest();
+  }
+  throw new TypeError(
+    `Unsupported hash ${hash}. Must be one of SHA(1|256|512).`
+  );
+}

--- a/src/bundles/sha256/LICENSE
+++ b/src/bundles/sha256/LICENSE
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Original work (c) Marco Paland (marco@paland.com) 2015-2018, PALANDesign Hannover, Germany
+
+Deno port Copyright (c) 2019 Noah Anabiik Schwarz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/bundles/sha256/mod.ts
+++ b/src/bundles/sha256/mod.ts
@@ -1,0 +1,228 @@
+/** Byte length of a SHA256 hash. */
+export const BYTES: number = 32;
+
+/** A class representation of the SHA256 algorithm. */
+export class SHA256 {
+  readonly hashSize: number = BYTES;
+
+  private _buf: Uint8Array;
+  private _bufIdx!: number;
+  private _count!: Uint32Array;
+  private _K: Uint32Array;
+  private _H!: Uint32Array;
+  private _finalized!: boolean;
+
+  /** Creates a SHA256 instance. */
+  constructor() {
+    this._buf = new Uint8Array(64);
+
+    // prettier-ignore
+    this._K = new Uint32Array([
+      0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+      0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+      0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+      0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+      0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+      0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+      0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+      0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+      0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+      0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+      0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+      0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+      0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+      0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+      0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+      0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+    ]);
+
+    this.init();
+  }
+
+  /** Initializes a hash. */
+  init(): SHA256 {
+    // prettier-ignore
+    this._H = new Uint32Array([
+      0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+      0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+    ]);
+
+    this._bufIdx = 0;
+    this._count = new Uint32Array(2);
+    this._buf.fill(0);
+    this._finalized = false;
+
+    return this;
+  }
+
+  /** Updates the hash with additional message data. */
+  update(msg: Uint8Array): SHA256 {
+    if (msg === null) {
+      throw new TypeError("msg must be a string or Uint8Array.");
+    }
+
+    // process the msg as many times as possible, the rest is stored in the buffer
+    // message is processed in 512 bit (64 byte chunks)
+    for (let i: number = 0, len = msg.length; i < len; i++) {
+      this._buf[this._bufIdx++] = msg[i];
+
+      if (this._bufIdx === 64) {
+        this._transform();
+        this._bufIdx = 0;
+      }
+    }
+
+    // counter update (number of message bits)
+    const c: Uint32Array = this._count;
+
+    if ((c[0] += msg.length << 3) < msg.length << 3) {
+      c[1]++;
+    }
+
+    c[1] += msg.length >>> 29;
+
+    return this;
+  }
+
+  /** Finalizes the hash with additional message data. */
+  digest(): Uint8Array {
+    if (this._finalized) {
+      throw new Error("digest has already been called.")
+    }
+
+    this._finalized = true;
+
+    // append '1'
+    const b: Uint8Array = this._buf;
+    let idx: number = this._bufIdx;
+    b[idx++] = 0x80;
+
+    // zeropad up to byte pos 56
+    while (idx !== 56) {
+      if (idx === 64) {
+        this._transform();
+        idx = 0;
+      }
+      b[idx++] = 0;
+    }
+
+    // append length in bits
+    const c: Uint32Array = this._count;
+
+    b[56] = (c[1] >>> 24) & 0xff;
+    b[57] = (c[1] >>> 16) & 0xff;
+    b[58] = (c[1] >>> 8) & 0xff;
+    b[59] = (c[1] >>> 0) & 0xff;
+    b[60] = (c[0] >>> 24) & 0xff;
+    b[61] = (c[0] >>> 16) & 0xff;
+    b[62] = (c[0] >>> 8) & 0xff;
+    b[63] = (c[0] >>> 0) & 0xff;
+
+    this._transform();
+
+    // return the hash as byte array
+    const hash: Uint8Array = new Uint8Array(BYTES);
+
+    // let i: number;
+    for (let i: number = 0; i < 8; i++) {
+      hash[(i << 2) + 0] = (this._H[i] >>> 24) & 0xff;
+      hash[(i << 2) + 1] = (this._H[i] >>> 16) & 0xff;
+      hash[(i << 2) + 2] = (this._H[i] >>> 8) & 0xff;
+      hash[(i << 2) + 3] = (this._H[i] >>> 0) & 0xff;
+    }
+
+    // clear internal states and prepare for new hash
+    this.init();
+
+    return hash;
+  }
+
+  /** Performs one transformation cycle. */
+  private _transform(): void {
+    const h: Uint32Array = this._H;
+
+    let h0: number = h[0];
+    let h1: number = h[1];
+    let h2: number = h[2];
+    let h3: number = h[3];
+    let h4: number = h[4];
+    let h5: number = h[5];
+    let h6: number = h[6];
+    let h7: number = h[7];
+
+    // convert byte buffer into w[0..15]
+    const w: Uint32Array = new Uint32Array(16);
+    let i: number;
+
+    for (i = 0; i < 16; i++) {
+      w[i] =
+        this._buf[(i << 2) + 3] |
+        (this._buf[(i << 2) + 2] << 8) |
+        (this._buf[(i << 2) + 1] << 16) |
+        (this._buf[i << 2] << 24);
+    }
+
+    for (i = 0; i < 64; i++) {
+      let tmp: number;
+      if (i < 16) {
+        tmp = w[i];
+      } else {
+        let a = w[(i + 1) & 15];
+        let b = w[(i + 14) & 15];
+        tmp = w[i & 15] =
+          (((a >>> 7) ^ (a >>> 18) ^ (a >>> 3) ^ (a << 25) ^ (a << 14)) +
+            ((b >>> 17) ^ (b >>> 19) ^ (b >>> 10) ^ (b << 15) ^ (b << 13)) +
+            w[i & 15] +
+            w[(i + 9) & 15]) |
+          0;
+      }
+
+      tmp =
+        (tmp +
+          h7 +
+          ((h4 >>> 6) ^
+            (h4 >>> 11) ^
+            (h4 >>> 25) ^
+            (h4 << 26) ^
+            (h4 << 21) ^
+            (h4 << 7)) +
+          (h6 ^ (h4 & (h5 ^ h6))) +
+          this._K[i]) |
+        0;
+
+      h7 = h6;
+      h6 = h5;
+      h5 = h4;
+      h4 = h3 + tmp;
+      h3 = h2;
+      h2 = h1;
+      h1 = h0;
+      h0 =
+        (tmp +
+          ((h1 & h2) ^ (h3 & (h1 ^ h2))) +
+          ((h1 >>> 2) ^
+            (h1 >>> 13) ^
+            (h1 >>> 22) ^
+            (h1 << 30) ^
+            (h1 << 19) ^
+            (h1 << 10))) |
+        0;
+    }
+
+    h[0] = (h[0] + h0) | 0;
+    h[1] = (h[1] + h1) | 0;
+    h[2] = (h[2] + h2) | 0;
+    h[3] = (h[3] + h3) | 0;
+    h[4] = (h[4] + h4) | 0;
+    h[5] = (h[5] + h5) | 0;
+    h[6] = (h[6] + h6) | 0;
+    h[7] = (h[7] + h7) | 0;
+  }
+}
+
+/** Generates a SHA256 hash of the input data. */
+export function sha256(
+  msg: Uint8Array,
+): Uint8Array {
+  return new SHA256().update(msg).digest();
+}

--- a/src/bundles/sha512/LICENSE
+++ b/src/bundles/sha512/LICENSE
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Original work (c) Marco Paland (marco@paland.com) 2015-2018, PALANDesign Hannover, Germany
+
+Deno port Copyright (c) 2019 Noah Anabiik Schwarz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/bundles/sha512/mod.ts
+++ b/src/bundles/sha512/mod.ts
@@ -1,0 +1,369 @@
+/** Byte length of a SHA512 hash. */
+export const BYTES: number = 64;
+
+/** A class representation of the SHA2-512 algorithm. */
+export class SHA512 {
+  readonly hashSize: number = BYTES;
+
+  private _buffer: Uint8Array = new Uint8Array(128);
+  private _bufferIndex!: number;
+  private _count!: Uint32Array;
+  private _K: Uint32Array;
+  private _H!: Uint32Array;
+  private _finalized!: boolean;
+
+  /** Creates a SHA512 instance. */
+  constructor() {
+    // prettier-ignore
+    this._K = new Uint32Array([
+      0x428a2f98, 0xd728ae22, 0x71374491, 0x23ef65cd, 0xb5c0fbcf, 0xec4d3b2f,
+      0xe9b5dba5, 0x8189dbbc, 0x3956c25b, 0xf348b538, 0x59f111f1, 0xb605d019,
+      0x923f82a4, 0xaf194f9b, 0xab1c5ed5, 0xda6d8118, 0xd807aa98, 0xa3030242,
+      0x12835b01, 0x45706fbe, 0x243185be, 0x4ee4b28c, 0x550c7dc3, 0xd5ffb4e2,
+      0x72be5d74, 0xf27b896f, 0x80deb1fe, 0x3b1696b1, 0x9bdc06a7, 0x25c71235,
+      0xc19bf174, 0xcf692694, 0xe49b69c1, 0x9ef14ad2, 0xefbe4786, 0x384f25e3,
+      0x0fc19dc6, 0x8b8cd5b5, 0x240ca1cc, 0x77ac9c65, 0x2de92c6f, 0x592b0275,
+      0x4a7484aa, 0x6ea6e483, 0x5cb0a9dc, 0xbd41fbd4, 0x76f988da, 0x831153b5,
+      0x983e5152, 0xee66dfab, 0xa831c66d, 0x2db43210, 0xb00327c8, 0x98fb213f,
+      0xbf597fc7, 0xbeef0ee4, 0xc6e00bf3, 0x3da88fc2, 0xd5a79147, 0x930aa725,
+      0x06ca6351, 0xe003826f, 0x14292967, 0x0a0e6e70, 0x27b70a85, 0x46d22ffc,
+      0x2e1b2138, 0x5c26c926, 0x4d2c6dfc, 0x5ac42aed, 0x53380d13, 0x9d95b3df,
+      0x650a7354, 0x8baf63de, 0x766a0abb, 0x3c77b2a8, 0x81c2c92e, 0x47edaee6,
+      0x92722c85, 0x1482353b, 0xa2bfe8a1, 0x4cf10364, 0xa81a664b, 0xbc423001,
+      0xc24b8b70, 0xd0f89791, 0xc76c51a3, 0x0654be30, 0xd192e819, 0xd6ef5218,
+      0xd6990624, 0x5565a910, 0xf40e3585, 0x5771202a, 0x106aa070, 0x32bbd1b8,
+      0x19a4c116, 0xb8d2d0c8, 0x1e376c08, 0x5141ab53, 0x2748774c, 0xdf8eeb99,
+      0x34b0bcb5, 0xe19b48a8, 0x391c0cb3, 0xc5c95a63, 0x4ed8aa4a, 0xe3418acb,
+      0x5b9cca4f, 0x7763e373, 0x682e6ff3, 0xd6b2b8a3, 0x748f82ee, 0x5defb2fc,
+      0x78a5636f, 0x43172f60, 0x84c87814, 0xa1f0ab72, 0x8cc70208, 0x1a6439ec,
+      0x90befffa, 0x23631e28, 0xa4506ceb, 0xde82bde9, 0xbef9a3f7, 0xb2c67915,
+      0xc67178f2, 0xe372532b, 0xca273ece, 0xea26619c, 0xd186b8c7, 0x21c0c207,
+      0xeada7dd6, 0xcde0eb1e, 0xf57d4f7f, 0xee6ed178, 0x06f067aa, 0x72176fba,
+      0x0a637dc5, 0xa2c898a6, 0x113f9804, 0xbef90dae, 0x1b710b35, 0x131c471b,
+      0x28db77f5, 0x23047d84, 0x32caab7b, 0x40c72493, 0x3c9ebe0a, 0x15c9bebc,
+      0x431d67c4, 0x9c100d4c, 0x4cc5d4be, 0xcb3e42b6, 0x597f299c, 0xfc657e2a,
+      0x5fcb6fab, 0x3ad6faec, 0x6c44198c, 0x4a475817
+    ]);
+
+    this.init();
+  }
+
+  /** Initializes a SHA512 instance. */
+  init(): SHA512 {
+    // prettier-ignore
+    this._H = new Uint32Array([
+      0x6a09e667, 0xf3bcc908, 0xbb67ae85, 0x84caa73b, 0x3c6ef372, 0xfe94f82b,
+      0xa54ff53a, 0x5f1d36f1, 0x510e527f, 0xade682d1, 0x9b05688c, 0x2b3e6c1f,
+      0x1f83d9ab, 0xfb41bd6b, 0x5be0cd19, 0x137e2179
+    ]);
+
+    this._bufferIndex = 0;
+    this._count = new Uint32Array(2);
+    this._buffer.fill(0);
+    this._finalized = false;
+
+    return this;
+  }
+
+  /** Updates the hash with additional message data. */
+  update(msg: Uint8Array): SHA512 {
+    if (msg === null) {
+      throw new TypeError("msg must be a string or Uint8Array.");
+    }
+
+    // process the msg as many times as possible, the rest is stored in the
+    // buffer; message is processed in 1024 bit (128 byte chunks)
+    for (let i = 0; i < msg.length; i++) {
+      this._buffer[this._bufferIndex++] = msg[i];
+      if (this._bufferIndex === 128) {
+        this.transform();
+        this._bufferIndex = 0;
+      }
+    }
+
+    // counter update (number of message bits)
+    let c = this._count;
+
+    if ((c[0] += msg.length << 3) < msg.length << 3) {
+      c[1]++;
+    }
+
+    c[1] += msg.length >>> 29;
+
+    return this;
+ }
+
+  /** Finalizes the hash with additional message data. */
+  digest(): Uint8Array {
+    if (this._finalized) {
+      throw new Error("digest has already been called.")
+    }
+
+    this._finalized = true;
+
+    // append '1'
+    var b = this._buffer,
+      idx = this._bufferIndex;
+    b[idx++] = 0x80;
+
+    // zeropad up to byte pos 112
+    while (idx !== 112) {
+      if (idx === 128) {
+        this.transform();
+        idx = 0;
+      }
+      b[idx++] = 0;
+    }
+
+    // append length in bits
+    let c = this._count;
+
+    b[112] = b[113] = b[114] = b[115] = b[116] = b[117] = b[118] = b[119] = 0;
+    b[120] = (c[1] >>> 24) & 0xff;
+    b[121] = (c[1] >>> 16) & 0xff;
+    b[122] = (c[1] >>> 8) & 0xff;
+    b[123] = (c[1] >>> 0) & 0xff;
+    b[124] = (c[0] >>> 24) & 0xff;
+    b[125] = (c[0] >>> 16) & 0xff;
+    b[126] = (c[0] >>> 8) & 0xff;
+    b[127] = (c[0] >>> 0) & 0xff;
+
+    this.transform();
+
+    // return the hash as byte array
+    let i,
+      hash = new Uint8Array(64);
+
+    for (i = 0; i < 16; i++) {
+      hash[(i << 2) + 0] = (this._H[i] >>> 24) & 0xff;
+      hash[(i << 2) + 1] = (this._H[i] >>> 16) & 0xff;
+      hash[(i << 2) + 2] = (this._H[i] >>> 8) & 0xff;
+      hash[(i << 2) + 3] = this._H[i] & 0xff;
+    }
+
+    // clear internal states and prepare for new hash
+    this.init();
+
+    return hash;
+  }
+
+  /** Performs one transformation cycle. */
+  private transform(): void {
+    let h = this._H,
+      h0h = h[0],
+      h0l = h[1],
+      h1h = h[2],
+      h1l = h[3],
+      h2h = h[4],
+      h2l = h[5],
+      h3h = h[6],
+      h3l = h[7],
+      h4h = h[8],
+      h4l = h[9],
+      h5h = h[10],
+      h5l = h[11],
+      h6h = h[12],
+      h6l = h[13],
+      h7h = h[14],
+      h7l = h[15];
+
+    let ah = h0h,
+      al = h0l,
+      bh = h1h,
+      bl = h1l,
+      ch = h2h,
+      cl = h2l,
+      dh = h3h,
+      dl = h3l,
+      eh = h4h,
+      el = h4l,
+      fh = h5h,
+      fl = h5l,
+      gh = h6h,
+      gl = h6l,
+      hh = h7h,
+      hl = h7l;
+
+    // convert byte buffer into w[0..31]
+    let i,
+      w = new Uint32Array(160);
+
+    for (i = 0; i < 32; i++) {
+      w[i] =
+        this._buffer[(i << 2) + 3] |
+        (this._buffer[(i << 2) + 2] << 8) |
+        (this._buffer[(i << 2) + 1] << 16) |
+        (this._buffer[i << 2] << 24);
+    }
+
+    // fill w[32..159]
+    let gamma0xl,
+      gamma0xh,
+      gamma0l,
+      gamma0h,
+      gamma1xl,
+      gamma1xh,
+      gamma1l,
+      gamma1h,
+      wrl,
+      wrh,
+      wr7l,
+      wr7h,
+      wr16l,
+      wr16h;
+
+    for (i = 16; i < 80; i++) {
+      // Gamma0
+      gamma0xh = w[(i - 15) * 2];
+      gamma0xl = w[(i - 15) * 2 + 1];
+      gamma0h =
+        ((gamma0xl << 31) | (gamma0xh >>> 1)) ^
+        ((gamma0xl << 24) | (gamma0xh >>> 8)) ^
+        (gamma0xh >>> 7);
+      gamma0l =
+        ((gamma0xh << 31) | (gamma0xl >>> 1)) ^
+        ((gamma0xh << 24) | (gamma0xl >>> 8)) ^
+        ((gamma0xh << 25) | (gamma0xl >>> 7));
+
+      // Gamma1
+      gamma1xh = w[(i - 2) * 2];
+      gamma1xl = w[(i - 2) * 2 + 1];
+      gamma1h =
+        ((gamma1xl << 13) | (gamma1xh >>> 19)) ^
+        ((gamma1xh << 3) | (gamma1xl >>> 29)) ^
+        (gamma1xh >>> 6);
+      gamma1l =
+        ((gamma1xh << 13) | (gamma1xl >>> 19)) ^
+        ((gamma1xl << 3) | (gamma1xh >>> 29)) ^
+        ((gamma1xh << 26) | (gamma1xl >>> 6));
+
+      // shortcuts
+      (wr7h = w[(i - 7) * 2]),
+        (wr7l = w[(i - 7) * 2 + 1]),
+        (wr16h = w[(i - 16) * 2]),
+        (wr16l = w[(i - 16) * 2 + 1]);
+
+      // W(round) = gamma0 + W(round - 7) + gamma1 + W(round - 16)
+      wrl = gamma0l + wr7l;
+      wrh = gamma0h + wr7h + (wrl >>> 0 < gamma0l >>> 0 ? 1 : 0);
+      wrl += gamma1l;
+      wrh += gamma1h + (wrl >>> 0 < gamma1l >>> 0 ? 1 : 0);
+      wrl += wr16l;
+      wrh += wr16h + (wrl >>> 0 < wr16l >>> 0 ? 1 : 0);
+
+      // store
+      w[i * 2] = wrh;
+      w[i * 2 + 1] = wrl;
+    }
+
+    // compress
+    let chl,
+      chh,
+      majl,
+      majh,
+      sig0l,
+      sig0h,
+      sig1l,
+      sig1h,
+      krl,
+      krh,
+      t1l,
+      t1h,
+      t2l,
+      t2h;
+
+    for (i = 0; i < 80; i++) {
+      // Ch
+      chh = (eh & fh) ^ (~eh & gh);
+      chl = (el & fl) ^ (~el & gl);
+
+      // Maj
+      majh = (ah & bh) ^ (ah & ch) ^ (bh & ch);
+      majl = (al & bl) ^ (al & cl) ^ (bl & cl);
+
+      // Sigma0
+      sig0h =
+        ((al << 4) | (ah >>> 28)) ^
+        ((ah << 30) | (al >>> 2)) ^
+        ((ah << 25) | (al >>> 7));
+      sig0l =
+        ((ah << 4) | (al >>> 28)) ^
+        ((al << 30) | (ah >>> 2)) ^
+        ((al << 25) | (ah >>> 7));
+
+      // Sigma1
+      sig1h =
+        ((el << 18) | (eh >>> 14)) ^
+        ((el << 14) | (eh >>> 18)) ^
+        ((eh << 23) | (el >>> 9));
+      sig1l =
+        ((eh << 18) | (el >>> 14)) ^
+        ((eh << 14) | (el >>> 18)) ^
+        ((el << 23) | (eh >>> 9));
+
+      // K(round)
+      krh = this._K[i * 2];
+      krl = this._K[i * 2 + 1];
+
+      // t1 = h + sigma1 + ch + K(round) + W(round)
+      t1l = hl + sig1l;
+      t1h = hh + sig1h + (t1l >>> 0 < hl >>> 0 ? 1 : 0);
+      t1l += chl;
+      t1h += chh + (t1l >>> 0 < chl >>> 0 ? 1 : 0);
+      t1l += krl;
+      t1h += krh + (t1l >>> 0 < krl >>> 0 ? 1 : 0);
+      t1l = t1l + w[i * 2 + 1];
+      t1h += w[i * 2] + (t1l >>> 0 < w[i * 2 + 1] >>> 0 ? 1 : 0);
+
+      // t2 = sigma0 + maj
+      t2l = sig0l + majl;
+      t2h = sig0h + majh + (t2l >>> 0 < sig0l >>> 0 ? 1 : 0);
+
+      // update working variables
+      hh = gh;
+      hl = gl;
+      gh = fh;
+      gl = fl;
+      fh = eh;
+      fl = el;
+      el = (dl + t1l) | 0;
+      eh = (dh + t1h + (el >>> 0 < dl >>> 0 ? 1 : 0)) | 0;
+      dh = ch;
+      dl = cl;
+      ch = bh;
+      cl = bl;
+      bh = ah;
+      bl = al;
+      al = (t1l + t2l) | 0;
+      ah = (t1h + t2h + (al >>> 0 < t1l >>> 0 ? 1 : 0)) | 0;
+    }
+
+    // intermediate hash
+    h0l = h[1] = (h0l + al) | 0;
+    h[0] = (h0h + ah + (h0l >>> 0 < al >>> 0 ? 1 : 0)) | 0;
+    h1l = h[3] = (h1l + bl) | 0;
+    h[2] = (h1h + bh + (h1l >>> 0 < bl >>> 0 ? 1 : 0)) | 0;
+    h2l = h[5] = (h2l + cl) | 0;
+    h[4] = (h2h + ch + (h2l >>> 0 < cl >>> 0 ? 1 : 0)) | 0;
+    h3l = h[7] = (h3l + dl) | 0;
+    h[6] = (h3h + dh + (h3l >>> 0 < dl >>> 0 ? 1 : 0)) | 0;
+    h4l = h[9] = (h4l + el) | 0;
+    h[8] = (h4h + eh + (h4l >>> 0 < el >>> 0 ? 1 : 0)) | 0;
+    h5l = h[11] = (h5l + fl) | 0;
+    h[10] = (h5h + fh + (h5l >>> 0 < fl >>> 0 ? 1 : 0)) | 0;
+    h6l = h[13] = (h6l + gl) | 0;
+    h[12] = (h6h + gh + (h6l >>> 0 < gl >>> 0 ? 1 : 0)) | 0;
+    h7l = h[15] = (h7l + hl) | 0;
+    h[14] = (h7h + hh + (h7l >>> 0 < hl >>> 0 ? 1 : 0)) | 0;
+  }
+}
+
+/** Obtain a SHA512 hash of an utf8 encoded string or an Uint8Array. */
+export function sha512(
+  msg: Uint8Array,
+): Uint8Array {
+  return new SHA512()
+    .init()
+    .update(msg)
+    .digest();
+}

--- a/src/cipherSuite.ts
+++ b/src/cipherSuite.ts
@@ -46,6 +46,12 @@ export class CipherSuite {
   public readonly kdf: Kdf;
   /** The AEAD id of the cipher suite. */
   public readonly aead: Aead;
+  /** The length in bytes of an AEAD key. */
+  public readonly aeadKeySize: number = 0;
+  /** The length in bytes of an AEAD nonce. */
+  public readonly aeadNonceSize: number = 0;
+  /** The length in bytes of an AEAD authentication tag. */
+  public readonly aeadTagSize: number = 0;
 
   private _ctx: CipherSuiteParams;
   private _kem: KemContext | undefined = undefined;
@@ -83,8 +89,20 @@ export class CipherSuite {
 
     switch (params.aead) {
       case Aead.Aes128Gcm:
+        this.aeadKeySize = 16;
+        this.aeadNonceSize = 12;
+        this.aeadTagSize = 16;
+        break;
       case Aead.Aes256Gcm:
+        this.aeadKeySize = 32;
+        this.aeadNonceSize = 12;
+        this.aeadTagSize = 16;
+        break;
       case Aead.Chacha20Poly1305:
+        this.aeadKeySize = 32;
+        this.aeadNonceSize = 12;
+        this.aeadTagSize = 16;
+        break;
       case Aead.ExportOnly:
         break;
       default:

--- a/src/cipherSuite.ts
+++ b/src/cipherSuite.ts
@@ -1,4 +1,6 @@
+import type { AeadKey } from "./interfaces/aeadKey.ts";
 import type { CipherSuiteParams } from "./interfaces/cipherSuiteParams.ts";
+import type { KdfInterface } from "./interfaces/kdfInterface.ts";
 import type { KeyScheduleParams } from "./interfaces/keyScheduleParams.ts";
 import type { CipherSuiteSealResponse } from "./interfaces/responses.ts";
 import type { RecipientContextParams } from "./interfaces/recipientContextParams.ts";
@@ -12,6 +14,7 @@ import {
   RecipientExporterContext,
   SenderExporterContext,
 } from "./exporterContext.ts";
+import { createAeadKey } from "./encryptionContext.ts";
 import { Aead, Kdf, Kem, Mode } from "./identifiers.ts";
 import { KdfContext } from "./kdfContext.ts";
 import { KemContext } from "./kemContext.ts";
@@ -89,6 +92,28 @@ export class CipherSuite {
     }
     this.aead = params.aead;
     this._ctx = { kem: this.kem, kdf: this.kdf, aead: this.aead };
+  }
+
+  /**
+   * Gets a suite-specific KDF context.
+   *
+   * @returns A KDF context.
+   */
+  public async kdfContext(): Promise<KdfInterface> {
+    await this.setup();
+    return this._kdf as KdfContext;
+  }
+
+  /**
+   * Creates a suite-specific AEAD key.
+   *
+   * @param key A byte string of the raw key.
+   *
+   * @returns An AEAD key.
+   */
+  public async createAeadKey(key: ArrayBuffer): Promise<AeadKey> {
+    const api = await this.setup();
+    return createAeadKey(this.aead, key, api);
   }
 
   /**

--- a/src/interfaces/kdfInterface.ts
+++ b/src/interfaces/kdfInterface.ts
@@ -1,0 +1,35 @@
+/**
+ * The KDF interface.
+ */
+export interface KdfInterface {
+  extract(
+    salt: ArrayBuffer,
+    ikm: ArrayBuffer,
+  ): Promise<ArrayBuffer>;
+
+  expand(
+    prk: ArrayBuffer,
+    info: ArrayBuffer,
+    len: number,
+  ): Promise<ArrayBuffer>;
+
+  extractAndExpand(
+    salt: ArrayBuffer,
+    ikm: ArrayBuffer,
+    info: ArrayBuffer,
+    len: number,
+  ): Promise<ArrayBuffer>;
+
+  labeledExtract(
+    salt: ArrayBuffer,
+    label: Uint8Array,
+    ikm: Uint8Array,
+  ): Promise<ArrayBuffer>;
+
+  labeledExpand(
+    prk: ArrayBuffer,
+    label: Uint8Array,
+    info: Uint8Array,
+    len: number,
+  ): Promise<ArrayBuffer>;
+}

--- a/src/kdfCommon.ts
+++ b/src/kdfCommon.ts
@@ -1,8 +1,10 @@
+import type { KdfInterface } from "./interfaces/kdfInterface.ts";
+
 import { WebCrypto } from "./webCrypto.ts";
 
 import * as consts from "./consts.ts";
 
-export class KdfCommon extends WebCrypto {
+export class KdfCommon extends WebCrypto implements KdfInterface {
   protected readonly suiteId: Uint8Array;
   protected readonly algHash: HmacKeyGenParams;
   protected readonly _nH: number;
@@ -48,7 +50,7 @@ export class KdfCommon extends WebCrypto {
     return ret;
   }
 
-  protected async extract(
+  public async extract(
     salt: ArrayBuffer,
     ikm: ArrayBuffer,
   ): Promise<ArrayBuffer> {
@@ -61,7 +63,7 @@ export class KdfCommon extends WebCrypto {
     return await this._api.sign("HMAC", key, ikm);
   }
 
-  protected async expand(
+  public async expand(
     prk: ArrayBuffer,
     info: ArrayBuffer,
     len: number,
@@ -104,7 +106,7 @@ export class KdfCommon extends WebCrypto {
     return okm;
   }
 
-  protected async extractAndExpand(
+  public async extractAndExpand(
     salt: ArrayBuffer,
     ikm: ArrayBuffer,
     info: ArrayBuffer,

--- a/test/cipherSuite.test.ts
+++ b/test/cipherSuite.test.ts
@@ -1231,8 +1231,7 @@ describe("CipherSuite", () => {
 
       const responseNonce = new Uint8Array(suite.aeadKeySize);
       cryptoApi.getRandomValues(responseNonce);
-      const saltS = concat(new Uint8Array(sender.enc), responseNonce)
-        .slice(0, 32); // TODO fix
+      const saltS = concat(new Uint8Array(sender.enc), responseNonce);
 
       const kdfS = await suite.kdfContext();
       const prkS = await kdfS.extract(saltS, new Uint8Array(secretS));
@@ -1265,8 +1264,7 @@ describe("CipherSuite", () => {
       const saltR = concat(
         new Uint8Array(sender.enc),
         encResponse.slice(0, suite.aeadKeySize),
-      )
-        .slice(0, 32); // TODO fix
+      );
       const kdfR = await suite.kdfContext();
       const prkR = await kdfR.extract(
         saltR,
@@ -1287,6 +1285,118 @@ describe("CipherSuite", () => {
 
       // pt === "This is the response."
       assertEquals(response, new Uint8Array(pt));
+    });
+  });
+
+  describe("A README example of Oblivious HTTP (HKDF-SHA512)", () => {
+    it("should work normally", async () => {
+      if (isDeno()) {
+        return;
+      }
+      const te = new TextEncoder();
+      const cryptoApi = await loadCrypto();
+
+      const suite = new CipherSuite({
+        kem: Kem.DhkemP521HkdfSha512,
+        kdf: Kdf.HkdfSha512,
+        aead: Aead.Aes256Gcm,
+      });
+      const rkp = await suite.generateKeyPair();
+
+      // The sender (OHTTP client) side:
+      const response = te.encode("This is the response.");
+      const sender = await suite.createSenderContext({
+        recipientPublicKey: rkp.publicKey,
+      });
+
+      const secretS = await sender.export(
+        te.encode("message/bhttp response"),
+        suite.aeadKeySize,
+      );
+
+      const responseNonce = new Uint8Array(suite.aeadKeySize);
+      cryptoApi.getRandomValues(responseNonce);
+      const saltS = concat(new Uint8Array(sender.enc), responseNonce);
+
+      const kdfS = await suite.kdfContext();
+      const prkS = await kdfS.extract(saltS, new Uint8Array(secretS));
+      const keyS = await kdfS.expand(
+        prkS,
+        te.encode("key"),
+        suite.aeadKeySize,
+      );
+      const nonceS = await kdfS.expand(
+        prkS,
+        te.encode("nonce"),
+        suite.aeadNonceSize,
+      );
+
+      const aeadKeyS = await suite.createAeadKey(keyS);
+      const ct = await aeadKeyS.seal(nonceS, response, te.encode(""));
+      const encResponse = concat(responseNonce, new Uint8Array(ct));
+
+      // The recipient (OHTTP server) side:
+      const recipient = await suite.createRecipientContext({
+        recipientKey: rkp.privateKey,
+        enc: sender.enc,
+      });
+
+      const secretR = await recipient.export(
+        te.encode("message/bhttp response"),
+        suite.aeadKeySize,
+      );
+
+      const saltR = concat(
+        new Uint8Array(sender.enc),
+        encResponse.slice(0, suite.aeadKeySize),
+      );
+      const kdfR = await suite.kdfContext();
+      const prkR = await kdfR.extract(
+        saltR,
+        new Uint8Array(secretR),
+      );
+      const keyR = await kdfR.expand(prkR, te.encode("key"), suite.aeadKeySize);
+      const nonceR = await kdfR.expand(
+        prkR,
+        te.encode("nonce"),
+        suite.aeadNonceSize,
+      );
+      const aeadKeyR = await suite.createAeadKey(keyR);
+      const pt = await aeadKeyR.open(
+        nonceR,
+        encResponse.slice(suite.aeadKeySize),
+        te.encode(""),
+      );
+
+      // pt === "This is the response."
+      assertEquals(response, new Uint8Array(pt));
+    });
+  });
+
+  describe("kdfContext.extract/expand with unsupported key length", () => {
+    it("should throw NotSupportedError", async () => {
+      const cryptoApi = await loadCrypto();
+
+      // setup
+      const suite = new CipherSuite({
+        kem: Kem.DhkemP384HkdfSha384,
+        kdf: Kdf.HkdfSha384,
+        aead: Aead.Aes256Gcm,
+      });
+
+      const kdf = await suite.kdfContext();
+
+      const salt = new Uint8Array(48 + 32);
+      cryptoApi.getRandomValues(salt);
+
+      const ikm = new Uint8Array(48);
+      cryptoApi.getRandomValues(ikm);
+
+      // assert
+      await assertRejects(
+        () => kdf.extract(salt, ikm),
+        errors.NotSupportedError,
+      );
     });
   });
 });

--- a/test/kdfContext.test.ts
+++ b/test/kdfContext.test.ts
@@ -1,0 +1,139 @@
+import { assertEquals, assertRejects } from "testing/asserts.ts";
+
+import { describe, it } from "testing/bdd.ts";
+
+import { KdfContext } from "../src/kdfContext.ts";
+import { Aead, Kdf, Kem } from "../src/identifiers.ts";
+import { loadCrypto, loadSubtleCrypto } from "../src/webCrypto.ts";
+
+import * as errors from "../src/errors.ts";
+
+describe("extract/expand", () => {
+  describe("HKDF-SHA256 with valid parameters", () => {
+    it("should return a proper instance", async () => {
+      const te = new TextEncoder();
+
+      const api = await loadSubtleCrypto();
+      const cryptoApi = await loadCrypto();
+      const kdf = new KdfContext(api, {
+        kem: Kem.DhkemP256HkdfSha256,
+        kdf: Kdf.HkdfSha256,
+        aead: Aead.Aes128Gcm,
+      });
+
+      const salt = new Uint8Array(32);
+      cryptoApi.getRandomValues(salt);
+
+      const ikm = new Uint8Array(32);
+      cryptoApi.getRandomValues(ikm);
+
+      const prk = await kdf.extract(salt, ikm);
+      assertEquals(
+        typeof await kdf.expand(prk, te.encode("key"), 16),
+        "object",
+      );
+    });
+  });
+
+  describe("HKDF-SHA384 with valid parameters", () => {
+    it("should return a proper instance", async () => {
+      const te = new TextEncoder();
+
+      const api = await loadSubtleCrypto();
+      const cryptoApi = await loadCrypto();
+      const kdf = new KdfContext(api, {
+        kem: Kem.DhkemP384HkdfSha384,
+        kdf: Kdf.HkdfSha384,
+        aead: Aead.Aes128Gcm,
+      });
+
+      const salt = new Uint8Array(48);
+      cryptoApi.getRandomValues(salt);
+
+      const ikm = new Uint8Array(48);
+      cryptoApi.getRandomValues(ikm);
+
+      const prk = await kdf.extract(salt, ikm);
+      assertEquals(
+        typeof await kdf.expand(prk, te.encode("key"), 16),
+        "object",
+      );
+    });
+  });
+
+  describe("HKDF-SHA512 with valid parameters", () => {
+    it("should return a proper instance", async () => {
+      const te = new TextEncoder();
+
+      const api = await loadSubtleCrypto();
+      const cryptoApi = await loadCrypto();
+      const kdf = new KdfContext(api, {
+        kem: Kem.DhkemP521HkdfSha512,
+        kdf: Kdf.HkdfSha512,
+        aead: Aead.Aes128Gcm,
+      });
+
+      const salt = new Uint8Array(64);
+      cryptoApi.getRandomValues(salt);
+
+      const ikm = new Uint8Array(64);
+      cryptoApi.getRandomValues(ikm);
+
+      const prk = await kdf.extract(salt, ikm);
+      assertEquals(
+        typeof await kdf.expand(prk, te.encode("key"), 16),
+        "object",
+      );
+    });
+  });
+
+  describe("HKDF-SHA512 with over Nh length of salt.", () => {
+    it("should return a proper instance", async () => {
+      const te = new TextEncoder();
+      const api = await loadSubtleCrypto();
+      const cryptoApi = await loadCrypto();
+      const kdf = new KdfContext(api, {
+        kem: Kem.DhkemP521HkdfSha512,
+        kdf: Kdf.HkdfSha512,
+        aead: Aead.Aes128Gcm,
+      });
+
+      const salt = new Uint8Array(64 + 32);
+      cryptoApi.getRandomValues(salt);
+
+      const ikm = new Uint8Array(64);
+      cryptoApi.getRandomValues(ikm);
+
+      // assert
+      const prk = await kdf.extract(salt, ikm);
+      assertEquals(
+        typeof await kdf.expand(prk, te.encode("key"), 16),
+        "object",
+      );
+    });
+  });
+
+  describe("HKDF-SHA384 with unsupported salt length", () => {
+    it("should return a proper instance", async () => {
+      const api = await loadSubtleCrypto();
+      const cryptoApi = await loadCrypto();
+      const kdf = new KdfContext(api, {
+        kem: Kem.DhkemP384HkdfSha384,
+        kdf: Kdf.HkdfSha384,
+        aead: Aead.Aes128Gcm,
+      });
+
+      const salt = new Uint8Array(48 + 32);
+      cryptoApi.getRandomValues(salt);
+
+      const ikm = new Uint8Array(48);
+      cryptoApi.getRandomValues(ikm);
+
+      // assert
+      await assertRejects(
+        () => kdf.extract(salt, ikm),
+        errors.NotSupportedError,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Expose suite-specific KDF and AEAD interfaces for some HPKE applications (e.g., Oblivious HTTP).
Specifically, add following functions to hpke.CipherSuite class.
- kdfContext()
- createAeadKey()

Close #96