### PR TITLE
Increase the input limits from 128 bytes to 8192 bytes

### DIFF
--- a/core/test/cipherSuite.test.ts
+++ b/core/test/cipherSuite.test.ts
@@ -1300,7 +1300,7 @@ describe("CipherSuite", () => {
       });
 
       await assertRejects(
-        () => suite.deriveKeyPair((new Uint8Array(129)).buffer),
+        () => suite.deriveKeyPair((new Uint8Array(8193)).buffer),
         InvalidParamError,
         "Too long ikm",
       );
@@ -1321,7 +1321,7 @@ describe("CipherSuite", () => {
       await assertRejects(
         () =>
           suite.createSenderContext({
-            info: (new Uint8Array(129)).buffer,
+            info: (new Uint8Array(8193)).buffer,
             recipientPublicKey: rkp.publicKey,
           }),
         InvalidParamError,
@@ -1345,7 +1345,7 @@ describe("CipherSuite", () => {
         () =>
           suite.createSenderContext({
             psk: {
-              key: (new Uint8Array(129)).buffer,
+              key: (new Uint8Array(8193)).buffer,
               id: new Uint8Array([1, 2, 3, 4]),
             },
             recipientPublicKey: rkp.publicKey,
@@ -1398,7 +1398,7 @@ describe("CipherSuite", () => {
           suite.createSenderContext({
             psk: {
               key: new Uint8Array(32),
-              id: (new Uint8Array(129)).buffer,
+              id: (new Uint8Array(8193)).buffer,
             },
             recipientPublicKey: rkp.publicKey,
           }),

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,7 +4,7 @@ export const KEM_USAGES: KeyUsage[] = ["deriveBits"];
 export const AEAD_USAGES: KeyUsage[] = ["encrypt", "decrypt"];
 
 // The input length limit (psk, psk_id, info, exporter_context, ikm).
-export const INPUT_LENGTH_LIMIT = 128;
+export const INPUT_LENGTH_LIMIT = 8192;
 
 // The minimum length of a PSK.
 export const MINIMUM_PSK_LENGTH = 32;

--- a/test/cipherSuite.test.ts
+++ b/test/cipherSuite.test.ts
@@ -1226,7 +1226,7 @@ describe("CipherSuite", () => {
       });
 
       await assertRejects(
-        () => suite.deriveKeyPair((new Uint8Array(129)).buffer),
+        () => suite.deriveKeyPair((new Uint8Array(8193)).buffer),
         errors.InvalidParamError,
         "Too long ikm",
       );
@@ -1247,7 +1247,7 @@ describe("CipherSuite", () => {
       await assertRejects(
         () =>
           suite.createSenderContext({
-            info: (new Uint8Array(129)).buffer,
+            info: (new Uint8Array(8193)).buffer,
             recipientPublicKey: rkp.publicKey,
           }),
         errors.InvalidParamError,
@@ -1271,7 +1271,7 @@ describe("CipherSuite", () => {
         () =>
           suite.createSenderContext({
             psk: {
-              key: (new Uint8Array(129)).buffer,
+              key: (new Uint8Array(8193)).buffer,
               id: new Uint8Array([1, 2, 3, 4]),
             },
             recipientPublicKey: rkp.publicKey,
@@ -1324,7 +1324,7 @@ describe("CipherSuite", () => {
           suite.createSenderContext({
             psk: {
               key: new Uint8Array(32),
-              id: (new Uint8Array(129)).buffer,
+              id: (new Uint8Array(8193)).buffer,
             },
             recipientPublicKey: rkp.publicKey,
           }),

--- a/test/cipherSuiteBackwardCompat.test.ts
+++ b/test/cipherSuiteBackwardCompat.test.ts
@@ -1053,7 +1053,7 @@ describe("CipherSuite(backward-compat)", () => {
       });
 
       await assertRejects(
-        () => suite.deriveKeyPair((new Uint8Array(129)).buffer),
+        () => suite.deriveKeyPair((new Uint8Array(8193)).buffer),
         errors.InvalidParamError,
         "Too long ikm",
       );
@@ -1074,7 +1074,7 @@ describe("CipherSuite(backward-compat)", () => {
       await assertRejects(
         () =>
           suite.createSenderContext({
-            info: (new Uint8Array(129)).buffer,
+            info: (new Uint8Array(8193)).buffer,
             recipientPublicKey: rkp.publicKey,
           }),
         errors.InvalidParamError,
@@ -1098,7 +1098,7 @@ describe("CipherSuite(backward-compat)", () => {
         () =>
           suite.createSenderContext({
             psk: {
-              key: (new Uint8Array(129)).buffer,
+              key: (new Uint8Array(8193)).buffer,
               id: new Uint8Array([1, 2, 3, 4]),
             },
             recipientPublicKey: rkp.publicKey,
@@ -1151,7 +1151,7 @@ describe("CipherSuite(backward-compat)", () => {
           suite.createSenderContext({
             psk: {
               key: new Uint8Array(32),
-              id: (new Uint8Array(129)).buffer,
+              id: (new Uint8Array(8193)).buffer,
             },
             recipientPublicKey: rkp.publicKey,
           }),

--- a/test/cipherSuiteNative.test.ts
+++ b/test/cipherSuiteNative.test.ts
@@ -1307,7 +1307,7 @@ describe("CipherSuiteNative", () => {
       });
 
       await assertRejects(
-        () => suite.deriveKeyPair((new Uint8Array(129)).buffer),
+        () => suite.deriveKeyPair((new Uint8Array(8193)).buffer),
         InvalidParamError,
         "Too long ikm",
       );
@@ -1328,7 +1328,7 @@ describe("CipherSuiteNative", () => {
       await assertRejects(
         () =>
           suite.createSenderContext({
-            info: (new Uint8Array(129)).buffer,
+            info: (new Uint8Array(8193)).buffer,
             recipientPublicKey: rkp.publicKey,
           }),
         InvalidParamError,
@@ -1352,7 +1352,7 @@ describe("CipherSuiteNative", () => {
         () =>
           suite.createSenderContext({
             psk: {
-              key: (new Uint8Array(129)).buffer,
+              key: (new Uint8Array(8193)).buffer,
               id: new Uint8Array([1, 2, 3, 4]),
             },
             recipientPublicKey: rkp.publicKey,
@@ -1405,7 +1405,7 @@ describe("CipherSuiteNative", () => {
           suite.createSenderContext({
             psk: {
               key: new Uint8Array(32),
-              id: (new Uint8Array(129)).buffer,
+              id: (new Uint8Array(8193)).buffer,
             },
             recipientPublicKey: rkp.publicKey,
           }),

--- a/test/encryptionContext.test.ts
+++ b/test/encryptionContext.test.ts
@@ -263,7 +263,7 @@ describe("export", () => {
 
       // assert
       await assertRejects(
-        () => sender.export(new Uint8Array(129), 32),
+        () => sender.export(new Uint8Array(8193), 32),
         errors.InvalidParamError,
         "Too long exporter context",
       );


### PR DESCRIPTION
In particular, the 128 byte limit is problematic for `info` as used in
the Mobile Document Request API (https://github.com/WICG/mobile-document-request-api)
and similar schemes.
