### PR TITLE
fix: call _setup earlier in hybridkem-x-wing encap

### DIFF
--- a/packages/hybridkem-x-wing/src/xWing.ts
+++ b/packages/hybridkem-x-wing/src/xWing.ts
@@ -266,6 +266,7 @@ export class XWing implements KemInterface {
       }
       ekm = params.ekm;
     }
+    await this._setup();
     let ekM: Uint8Array | undefined = undefined;
     let ekX: Uint8Array;
     if (ekm !== undefined) {
@@ -286,7 +287,6 @@ export class XWing implements KemInterface {
     if (pk.byteLength !== 1216) {
       throw new InvalidParamError("Invalid length of recipientPublicKey");
     }
-    await this._setup();
     try {
       const pkM = pk.subarray(0, 1184);
       const pkX = pk.subarray(1184, 1216);


### PR DESCRIPTION
The `encap` function uses `this._api` at line 278 (`(this._api as Crypto).getRandomValues(ekX)`) but doesn't call `await this._setup()` until line 289. This means `this._api` could be `undefined` when first accessed, leading to runtime error.