### PR TITLE
ml-kem: fix encap/decap

### DIFF
--- a/packages/ml-kem/src/mlKem.ts
+++ b/packages/ml-kem/src/mlKem.ts
@@ -179,7 +179,7 @@ export class MlKemBase implements KemInterface {
     try {
       const [ct, ss] = await (this._prim as MlKemInterface).encap(pk, ekm);
       return {
-        sharedSecret: ss.buffer as ArrayBuffer,
+        sharedSecret: ss.buffer.slice(ss.byteOffset, ss.byteOffset + ss.byteLength) as ArrayBuffer,
         enc: ct.buffer as ArrayBuffer,
       };
     } catch (e: unknown) {
@@ -201,8 +201,8 @@ export class MlKemBase implements KemInterface {
     }
     try {
       const [_, exSk] = await (this._prim as MlKemInterface).deriveKeyPair(sk);
-      return (await (this._prim as MlKemInterface).decap(ct, exSk))
-        .buffer as ArrayBuffer;
+      const ss = await (this._prim as MlKemInterface).decap(ct, exSk);
+      return ss.buffer.slice(ss.byteOffset, ss.byteOffset + ss.byteLength) as ArrayBuffer;
     } catch (e: unknown) {
       throw new DecapError(e);
     }


### PR DESCRIPTION
ML-KEM's Nsecret is 32, the implementation's Encap/Decap currently returns 64 bytes instead of 32, this PR slices the SS underlying ArrayBuffer to get the expected 32 byteLength ArrayBuffer

Of course this can also be fixed by updating the underlying library such that it's returned Uint8Array and its ArrayBuffer have the same byteLength.

closes #670

I've confirmed this fix by cross testing with my own one-shot implementation and the [PQ HPKE vectors](https://github.com/hpkewg/hpke-pq/blob/main/test-vectors.json)