### PR TITLE
ci: publish cose, jose, and ohttp to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,3 +78,15 @@ jobs:
         continue-on-error: true
         working-directory: ./npm/packages/ml-kem
         run: npm publish
+      - name: Publish @hpke/cose to npm
+        continue-on-error: true
+        working-directory: ./npm/packages/cose
+        run: npm publish
+      - name: Publish @hpke/jose to npm
+        continue-on-error: true
+        working-directory: ./npm/packages/jose
+        run: npm publish
+      - name: Publish @hpke/ohttp to npm
+        continue-on-error: true
+        working-directory: ./npm/packages/ohttp
+        run: npm publish


### PR DESCRIPTION
Extend the release workflow with npm publish steps for the HPKE-based protocol packages alongside existing scoped publishes.