### PR TITLE
Edit LICENSE to include previous authors.

### DIFF
--- a/packages/chacha20poly1305/LICENSE
+++ b/packages/chacha20poly1305/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
 Copyright (c) 2023 Ajitomi Daisuke
+Copyright (c) 2022 Paul Miller (https://paulmillr.com)
+Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
AI prompt:

```
The module `chacha20poly1305` copied code from other package.
Specifically file `src/chacha/chacha.ts` used noble-ciphers code.

The header of `src/chacha/chacha.ts` mentions noble-ciphers and MIT license. 

Question: should `chacha20poly1305` file `LICENSE` also mention noble-ciphers?

Reply concisely.
```

AI reply:

Yes — most likely it should.

If `packages/chacha20poly1305/src/chacha/chacha.ts` contains copied/adapted code from `noble-ciphers`, then the `chacha20poly1305` package should generally include the required MIT license notice for that copied code in its distributed licensing materials. In practice, that usually means one of these:

- mention `noble-ciphers` in the package’s `LICENSE`, or
- include a separate `NOTICE` / `THIRD_PARTY_LICENSES` file, or
- otherwise ensure the MIT copyright + permission notice is shipped with the package.

A source-file header alone may be insufficient if the package is distributed separately.

Short version: **yes, the package should preserve the noble-ciphers MIT attribution somewhere in the package-level license materials.**